### PR TITLE
Add CI/CD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,23 @@
+name: Continuous Delivery
+
+on:
+  push:
+    tags:
+      - 'v*' # e.g. v1.0.0
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: alvrme/alpine-android:android-34-jdk17
+    env:
+      SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+      KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Decode keystore
+        run: echo $KEYSTORE_BASE64 | base64 --decode > keystore.jks
+      - name: Build AAB
+        run: ./gradlew bundleRelease
+      - uses: softprops/action-gh-release@v1
+        with:
+          files: HamsterListAndroid/build/outputs/bundle/release/*.aab

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: Continuous Integration
+
+on:
+  pull_request: null
+  push:
+    branches: [ main ]
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    container: alvrme/alpine-android:android-34-jdk17
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run Detekt
+        run: ./gradlew detekt
+
+  build:
+    runs-on: ubuntu-latest
+    container: alvrme/alpine-android:android-34-jdk17
+    env:
+      SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+      KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Decode keystore
+        run: echo $KEYSTORE_BASE64 | base64 --decode > keystore.jks
+      - name: Build AAB
+        run: ./gradlew bundleRelease
+      - uses: actions/upload-artifact@v3
+        with:
+          name: App Bundle
+          path: HamsterListAndroid/build/outputs/bundle/release/*.aab

--- a/HamsterListAndroid/build.gradle.kts
+++ b/HamsterListAndroid/build.gradle.kts
@@ -1,4 +1,5 @@
-import java.util.Properties
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 
 plugins {
     id("com.android.application")
@@ -6,7 +7,7 @@ plugins {
     id("io.gitlab.arturbosch.detekt") version "1.22.0"
 }
 
-apply(plugin = "io.gitlab.arturbosch.detekt")
+val buildTag = System.getenv("GITHUB_RUN_NUMBER") ?: DateTimeFormatter.ISO_LOCAL_DATE.format(LocalDate.now())!!
 
 android {
     namespace = "org.stratum0.hamsterlist.android"
@@ -16,17 +17,14 @@ android {
         minSdk = 26
         targetSdk = 34
         versionCode = 3
-        versionName = "1.1"
+        versionName = "1.1+$buildTag"
     }
     signingConfigs {
         register("app") {
-            val localProperties = Properties().apply {
-                load(project.rootProject.file("local.properties").inputStream())
-            }
-            keyAlias = localProperties.getProperty("keyAlias")
-            keyPassword = localProperties.getProperty("storePassword")
-            storeFile = file(localProperties.getProperty("storeFile"))
-            storePassword = localProperties.getProperty("storePassword")
+            keyAlias = "HamsterListKey"
+            keyPassword = System.getenv("SIGNING_PASSWORD") ?: ""
+            storeFile = file("../keystore.jks")
+            storePassword = System.getenv("SIGNING_PASSWORD") ?: ""
         }
     }
     buildFeatures {

--- a/HamsterListAndroid/build.gradle.kts
+++ b/HamsterListAndroid/build.gradle.kts
@@ -21,7 +21,7 @@ android {
     }
     signingConfigs {
         register("app") {
-            keyAlias = "HamsterListKey"
+            keyAlias = "hamsterList_release"
             keyPassword = System.getenv("SIGNING_PASSWORD") ?: ""
             storeFile = file("../keystore.jks")
             storePassword = System.getenv("SIGNING_PASSWORD") ?: ""

--- a/HamsterListAndroid/build.gradle.kts
+++ b/HamsterListAndroid/build.gradle.kts
@@ -15,7 +15,7 @@ android {
         applicationId = "org.stratum0.hamsterlist.android"
         minSdk = 26
         targetSdk = 34
-        versionCode = 2
+        versionCode = 3
         versionName = "1.1"
     }
     signingConfigs {


### PR DESCRIPTION
This includes two GitHub Actions workflows:
- CI: This will run Detekt and build the Android app on pull requests or pushes on `main`
- CD: This will create a new GitHub release (containing the app bundle) when pushing a `git tag vX.Y.Z`.

This requires the following CI variables or else the pipeline will fail:
- [x] `KEYSTORE_BASE64`
- [x] `SIGNING_PASSWORD`
