### PR TITLE
Edge to edge Support

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: alvrme/alpine-android:android-34-jdk17
+    container: alvrme/alpine-android:android-35-jdk21
     env:
       SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
       KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   analyze:
     runs-on: ubuntu-latest
-    container: alvrme/alpine-android:android-34-jdk17
+    container: alvrme/alpine-android:android-35-jdk21
     steps:
       - uses: actions/checkout@v3
       - name: Run Detekt
@@ -16,7 +16,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    container: alvrme/alpine-android:android-34-jdk17
+    container: alvrme/alpine-android:android-35-jdk21
     env:
       SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
       KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}

--- a/HamsterListAndroid/build.gradle.kts
+++ b/HamsterListAndroid/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 val buildTag = System.getenv("GITHUB_RUN_NUMBER") ?: DateTimeFormatter.ISO_LOCAL_DATE.format(LocalDate.now())!!
 
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(21)
 }
 
 android {
@@ -53,10 +53,6 @@ android {
             applicationIdSuffix = ".debug"
             versionNameSuffix = "-debug"
         }
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
     }
 }
 

--- a/HamsterListAndroid/src/main/java/org/stratum0/hamsterlist/android/MainActivity.kt
+++ b/HamsterListAndroid/src/main/java/org/stratum0/hamsterlist/android/MainActivity.kt
@@ -3,7 +3,9 @@ package org.stratum0.hamsterlist.android
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
@@ -27,13 +29,16 @@ class MainActivity : ComponentActivity() {
     private val settings: ObservableSettings by inject()
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        enableEdgeToEdge()
         super.onCreate(savedInstanceState)
         val autoLoadLast = settings.getBooleanOrNull(SettingsKey.AUTO_LOAD_LAST.name) ?: false
         val listId = settings.getStringOrNull(SettingsKey.CURRENT_LIST_ID.name).orEmpty()
         setContent {
             HamsterListTheme {
                 Surface(
-                    modifier = Modifier.fillMaxSize(),
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .safeDrawingPadding(),
                     color = MaterialTheme.colors.background
                 ) {
                     NavigationHost(

--- a/HamsterListAndroid/src/main/res/values/styles.xml
+++ b/HamsterListAndroid/src/main/res/values/styles.xml
@@ -1,3 +1,3 @@
 <resources>
-    <style name="AppTheme" parent="android:Theme.Material.NoActionBar"/>
+    <style name="AppTheme" parent="Theme.AppCompat.DayNight.NoActionBar"/>
 </resources>

--- a/HamsterListCore/build.gradle.kts
+++ b/HamsterListCore/build.gradle.kts
@@ -16,7 +16,7 @@ object Versions {
 
 kotlin {
     androidTarget()
-    jvmToolchain(17)
+    jvmToolchain(21)
 
     listOf(
         iosX64(),
@@ -87,9 +87,5 @@ android {
     compileSdk = 35
     defaultConfig {
         minSdk = 26
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
     }
 }


### PR DESCRIPTION
Android 15 forces edge to edge display, which causes the app to draws behind status bar and keyboard.

This adds inset handling and also enables edge to edge on all Android versions.

I also updated JVM toolchain to JDK 21, which is now bundled with Android Studio.

<img src="https://github.com/user-attachments/assets/889281a1-5eba-4b21-b5f3-28406d608b02" width=200 alt="app in dark mode"/>

<img src="https://github.com/user-attachments/assets/1b7d8748-2392-418b-b0c2-2d802d2be641" width=200 alt="app in light mode"/>
